### PR TITLE
dein instructions has too many lambda arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Before installing anything please read [SECURITY.md](SECURITY.md) and make sure 
     * [dein](https://github.com/Shougo/dein.vim)
 
         ```vim
-        call dein#add('glacambre/firenvim', { 'hook_post_update': { _ -> firenvim#install(0) } })
+        call dein#add('glacambre/firenvim', { 'hook_post_update': { -> firenvim#install(0) } })
         ```
 
     * [minpac](https://github.com/k-takata/minpac)


### PR DESCRIPTION
This plugin is amazing! One issue I noticed is that when installing the neovim plugin with dein I got an error about there being too many arguments to the `hook_post_update` callback. Everything works if I remove the argument to the callback.

I'm using dein v2.1 and neovim v0.4.4.